### PR TITLE
time check for unix nanoseconds

### DIFF
--- a/time.go
+++ b/time.go
@@ -35,7 +35,13 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		t.Time = time.Unix(int64(input), 0)
 		return nil
 	case int64:
-		t.Time = time.Unix(input, 0)
+		if input >= 1e10 {
+			sec := input / 1e9
+			nsec := input - (sec * 1e9)
+			t.Time = time.Unix(sec, nsec)
+		} else {
+			t.Time = time.Unix(input, 0)
+		}
 		return nil
 	case float64:
 		t.Time = time.Unix(int64(input), 0)


### PR DESCRIPTION
In case of large unix nanosecond timestamp split them to second and nanosecond part

Now we can use both of unix timestamps:
```
t.UnmarshalGraphQL(time.Now().UnixNano())
t.UnmarshalGraphQL(time.Now().Unix())
```